### PR TITLE
fixed ecut bug in lj

### DIFF
--- a/src/energies.cpp
+++ b/src/energies.cpp
@@ -52,7 +52,7 @@ void update_LJ_energies_simplified(vector<BEAD>& subunit_bead, double ecut, vect
 					 double elj = 1;//subunit_bead[j].epsilon;
 					 r6 = pow((r-del),6);
 					 subunit_bead[i].ne += 0.5*((4 * elj * (sigma6 / r6) * ((sigma6 / r6) - 1)) + elj);
-				 } else if ( r < ((del+1.12246205*shc)*ecut) && lj_attractive == true ){			//Attractive
+				 } else if ( r < (ecut) && lj_attractive == true ){			//Attractive
 					 double ecut6 = ecut * ecut * ecut * ecut * ecut * ecut;
 					 double ecut12 = ecut6 * ecut6;
 					 r6 = pow((r-del),6);

--- a/src/forces.cpp
+++ b/src/forces.cpp
@@ -100,7 +100,7 @@ void forceCalculation(vector<SUBUNIT> &protein, double lb, double ni, double qs,
                     ljForce += (r_vec ^ (48 * elj * ((sigma12 / r12) - 0.5 * (sigma6 / r6)) *
                                          (1 / (r * (r - del)))));
 
-                } else if (r < ((del + 1.12246205 * shc) * ecut) && lj_attractive == true) {            //Repulsive
+                } else if (r < (ecut) && lj_attractive == true) {            //Repulsive
 
                     double r3 = (r - del) * (r - del) * (r - del);
                     double r6 = r3 * r3;


### PR DESCRIPTION
@Lauren-Nilsson this fixes the uncharged case. but the charged case still deviates similarly as before. seems there is something else not right; likely in electrostatic function, but could be in choices of lj parameters.